### PR TITLE
Fix logs path formatting to align with aws state.

### DIFF
--- a/modules/aws-emr-cluster/main.tf
+++ b/modules/aws-emr-cluster/main.tf
@@ -48,7 +48,7 @@ resource "aws_emr_cluster" "emr-cluster" {
     }
   }
 
-  log_uri      = "s3n://${var.bucket_name_for_logs}/${var.bucket_path_to_logs}"
+  log_uri      = "s3n://${var.bucket_name_for_logs}/${var.bucket_path_to_logs}/"
   service_role = var.emr_service_role_arn
 
   # Upload HBase/Hadoop configuration to s3

--- a/modules/aws-emr-cluster/outputs.tf
+++ b/modules/aws-emr-cluster/outputs.tf
@@ -63,7 +63,7 @@ output "master_ebs_type" {
 }
 
 output "log_uri" {
-  value       = local.static_cluster ? aws_emr_cluster.emr-cluster[0].log_uri : "s3n://${var.bucket_name_for_logs}/${var.bucket_path_to_logs}"
+  value       = local.static_cluster ? aws_emr_cluster.emr-cluster[0].log_uri : "s3n://${var.bucket_name_for_logs}/${var.bucket_path_to_logs}/"
   description = "The path to the S3 location where logs for this cluster are stored."
 }
 


### PR DESCRIPTION
Ran into this while setting up an environment for @aditimarkale and my emr backup/restore experimenting.

Might just edit the release (0.11.1) from this morning that was fixed this issue - https://github.com/Datatamer/terraform-aws-emr/pull/32.