### PR TITLE
CA-9 - Add support for permissions boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # TAMR AWS EMR module
 
+## v5.1.0 - July 6th, 2021
+* Adds new variable `permissions_boundary` to set the permissions boundary for all IAM Roles created by the module
+
 ## v5.0.0 - July 1st, 2021
 * Remove wildcards from IAM policies where possible
 * Removes policy entirely for the ec2 role

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ No provider.
 | master\_instance\_type | The EC2 instance type of the master nodes | `string` | `"m4.xlarge"` | no |
 | master\_timeout\_action | Timeout action for master instances | `string` | `"SWITCH_TO_ON_DEMAND"` | no |
 | master\_timeout\_duration\_minutes | Spot provisioning timeout for master instances, in minutes | `number` | `10` | no |
+| permissions\_boundary | ARN of the policy that will be used to set the permissions boundary for all IAM Roles created by this module | `string` | `null` | no |
 | release\_label | The release label for the Amazon EMR release. | `string` | `"emr-5.29.0"` | no |
 | tamr\_cidrs | List of CIDRs for Tamr | `list(string)` | `[]` | no |
 | tamr\_sgs | Security Groups for the Tamr Instance | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ module "emr-iam" {
   emr_ec2_role_name                 = var.emr_ec2_role_name
   additional_tags                   = var.additional_tags
   arn_partition                     = var.arn_partition
-
+  permissions_boundary              = var.permissions_boundary
 }
 
 module "emr-cluster-config" {

--- a/modules/aws-emr-iam/README.md
+++ b/modules/aws-emr-iam/README.md
@@ -56,6 +56,7 @@ This module creates:
 | emr\_ec2\_role\_name | Name of the new IAM role for EMR EC2 instances | `string` | `"tamr_emr_ec2_role"` | no |
 | emr\_service\_iam\_policy\_name | Name for the IAM policy attached to the EMR Service role | `string` | `"tamr-emr-service-policy"` | no |
 | emr\_service\_role\_name | Name of the new IAM service role for the EMR cluster | `string` | `"tamr_emr_service_role"` | no |
+| permissions\_boundary | ARN of the policy that will be used to set the permissions boundary for all IAM Roles created by this module | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/aws-emr-iam/main.tf
+++ b/modules/aws-emr-iam/main.tf
@@ -22,8 +22,9 @@ data "aws_iam_policy_document" "emr_assume_role" {
 
 //The service role for EMR
 resource "aws_iam_role" "emr_service_role" {
-  name               = var.emr_service_role_name
-  assume_role_policy = data.aws_iam_policy_document.emr_assume_role.json
+  name                 = var.emr_service_role_name
+  assume_role_policy   = data.aws_iam_policy_document.emr_assume_role.json
+  permissions_boundary = var.permissions_boundary
 }
 
 //The minimal policy document for the EMR service role
@@ -405,8 +406,9 @@ data "aws_iam_policy_document" "ec2_assume_role" {
 
 //The IAM role for the EMR EC2 instance profile
 resource "aws_iam_role" "emr_ec2_instance_profile" {
-  name               = var.emr_ec2_role_name
-  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+  name                 = var.emr_ec2_role_name
+  assume_role_policy   = data.aws_iam_policy_document.ec2_assume_role.json
+  permissions_boundary = var.permissions_boundary
 }
 
 // The IAM role policy attachment(s) that attach s3 policy ARNs to the EMR EC2 iam role

--- a/modules/aws-emr-iam/variables.tf
+++ b/modules/aws-emr-iam/variables.tf
@@ -61,3 +61,9 @@ variable "arn_partition" {
   EOF
   default     = "aws"
 }
+
+variable "permissions_boundary" {
+  type        = string
+  description = "ARN of the policy that will be used to set the permissions boundary for all IAM Roles created by this module"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -350,3 +350,9 @@ variable "arn_partition" {
   EOF
   default     = "aws"
 }
+
+variable "permissions_boundary" {
+  type        = string
+  description = "ARN of the policy that will be used to set the permissions boundary for all IAM Roles created by this module"
+  default     = null
+}


### PR DESCRIPTION
To allow for further tightening of IAM permissions, the Tamr EMR module should allow users to set a permissions boundary that will be attached to the EMR Service and EC2 Instance IAM roles.

Summary of changes:

- Module now exposes a string variable `permissions_boundary`
- Expected value is the ARN of an existing policy (`null` by default)
- The variable is propagated to the `aws-emr-iam` submodule
- If provided, the permissions boundary is attached to the created IAM Roles